### PR TITLE
Possible Right-Click Fix

### DIFF
--- a/ControlItem.cs
+++ b/ControlItem.cs
@@ -97,7 +97,7 @@ namespace ItemControl
             }
             if (Karl.Whitelist && isAdmin)
             {
-                return true;
+                return base.AltFunctionUse(item, player);
             }
 
             if (item.IsAir)
@@ -117,7 +117,7 @@ namespace ItemControl
                 return false;
             }
 
-            return true;
+            return base.AltFunctionUse(item, player);
         }
 
         public override bool Shoot(Item item, Player player, ref Vector2 position, ref float speedX, ref float speedY, ref int type, ref int damage, ref float knockBack)


### PR DESCRIPTION
I would think returning the base `AltFunctionUse` method would return false. However, I am not sure. Replacing `return true;` with `base.AltFunctionUse(item, player);` seems to prevent the right-click issues, but then it may not be properly checking use on right-click. However, after testing right-click usage of items seems to work as intended.